### PR TITLE
Updating playbooks to allow hosts target to be changed via an extra var

### DIFF
--- a/playbooks/ocp-ldap-groups-sync.yml
+++ b/playbooks/ocp-ldap-groups-sync.yml
@@ -1,6 +1,6 @@
 ---
 - name: OCP | LDAP Groups Sync
-  hosts: masters[0]
+  hosts: all
   become: true
   vars:
     ocp_ldap_groups_sync_file: '/tmp/ocp_ldap_groups_sync.yml'

--- a/playbooks/ocp-ldap-groups-sync.yml
+++ b/playbooks/ocp-ldap-groups-sync.yml
@@ -1,6 +1,6 @@
 ---
 - name: OCP | LDAP Groups Sync
-  hosts: all
+  hosts: "{{ variable_host | default('masters[0]') }}"
   become: true
   vars:
     ocp_ldap_groups_sync_file: '/tmp/ocp_ldap_groups_sync.yml'

--- a/playbooks/ocp-prune.yml
+++ b/playbooks/ocp-prune.yml
@@ -1,6 +1,6 @@
 ---
 - name: OCP | Prune
-  hosts: masters[0]
+  hosts: "{{ variable_host | default('masters[0]') }}"
   tasks:
     - name: OCP | Prune Objects
       command: "oc adm prune {{ item }} --orphans --keep-complete={{ ocp_prune_keep_complete | default(1) }} --keep-failed={{ ocp_prune_keep_failed | default(0) }} --confirm"


### PR DESCRIPTION
original playbooks were geared towards OCP 3 architecture of assuming commands would be run on the master nodes.  In OCP 4 this is not the case and will need to be run from a bastion.  This code provides additional flexibility to meet each scenario.